### PR TITLE
Add a proof-of-concept for importing coffeelint.json from parent directories

### DIFF
--- a/coffeelint-server/src/server.ts
+++ b/coffeelint-server/src/server.ts
@@ -3,6 +3,7 @@
 import * as coffeeLint from 'coffeelint';
 import * as fs from 'fs';
 import * as path from 'path';
+import configFinder from 'coffeelint/lib/configfinder';
 import { URL } from 'url';
 
 import {
@@ -51,14 +52,10 @@ connection.onDidChangeConfiguration((change) => {
 
 function loadWorkspaceConfig(coffeeLintConfigURI) {
 	try {
-		// console.log(coffeeLintConfigURI);
-
-		let content = fs.readFileSync(coffeeLintConfigURI, 'utf-8').replace(new RegExp("//.*", "gi"), "");
-		workspaceConfig = JSON.parse(content);
+		workspaceConfig = configFinder.getConfig(coffeeLintConfigURI);
 	}
 	catch (error) {
-		// workspaceConfig = {};
-		console.log("No valide locale lint config");
+		console.log("No valid local lint config");
 	}
 
 	mergeConfig(settingConfig, workspaceConfig);


### PR DESCRIPTION
This PR attempts to use the built-in `coffeelint/configfinder` to locate `coffeelint.json` defined in a parent directory.

For my dev environment, I keep a `coffeelint.json` in the parent directory, and I do not include a `coffeelint.json` in the workspace directory of my project.

This implementation is based off of:

https://github.com/clutchski/coffeelint/issues/570#issuecomment-233390107

### Issues

- I don't use Typescript, and I had a very hard time trying to compile. I can't get past some compile errors for `vscode`. I have no idea if this code works.
- I also struggled to get the extension dev environment set up for vscode. It's more effort than I have time for.

If you could include a README for this extension of development, I'd really appreciate it! Thanks for building this linter extension.

**NOTE: This code is not tested and probably does NOT work**