### PR TITLE
Fixed broken badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Coffee Lint for VSCode
 
-<a href="https://marketplace.visualstudio.com/items?itemName=lkytal.coffeelinter"><img src="http://vsmarketplacebadge.apphb.com/version/lkytal.coffeelinter.svg?style=flat-square" alt="Installs"></a>
-<a href="https://marketplace.visualstudio.com/items?itemName=lkytal.coffeelinter"><img src="http://vsmarketplacebadge.apphb.com/installs/lkytal.coffeelinter.svg?style=flat-square" alt="Installs"></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=lkytal.coffeelinter"><img src="https://vsmarketplacebadges.dev/version/lkytal.coffeelinter.svg?style=flat-square" alt="Version"></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=lkytal.coffeelinter"><img src="https://vsmarketplacebadges.dev/installs/lkytal.coffeelinter.svg?style=flat-square" alt="Installs"></a>
 
 > Install [Coffee Lint](https://marketplace.visualstudio.com/items?itemName=lkytal.coffeelinter) via VSCode market.
 

--- a/coffeelint/README.md
+++ b/coffeelint/README.md
@@ -1,7 +1,7 @@
 # Coffee Lint for VSCode
 
-[![Dependency status](https://david-dm.org/lkytal/coffeelinter.svg?style=flat-square)](https://david-dm.org/lkytal/coffeelinter.svg?style=flat-square)
-<a href="https://marketplace.visualstudio.com/items?itemName=lkytal.coffeelinter"><img src="https://vsmarketplacebadge.apphb.com/installs/lkytal.coffeelinter.svg?style=flat-square" alt="Installs"></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=lkytal.coffeelinter"><img src="https://vsmarketplacebadges.dev/version/lkytal.coffeelinter.svg?style=flat-square" alt="Version"></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=lkytal.coffeelinter"><img src="https://vsmarketplacebadges.dev/installs/lkytal.coffeelinter.svg?style=flat-square" alt="Installs"></a>
 
 > Licensed by <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" title="Creative Commons BY-NC-SA 4.0" target="_blank">CC 4.0 BY-NC-SA</a>
 
@@ -27,6 +27,10 @@ This extension contributes the following settings:
 - ### [Translator Plus](https://marketplace.visualstudio.com/items?itemName=lkytal.translatorplus)
 
 ## Release Notes
+
+### 1.4.1
+
+- Fixed broken badge link.
 
 ### 1.4.0
 

--- a/coffeelint/package-lock.json
+++ b/coffeelint/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "coffeelinter",
-	"version": "1.3.1",
+	"version": "1.4.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/coffeelint/package.json
+++ b/coffeelint/package.json
@@ -4,7 +4,7 @@
 	"description": "CoffeeScript linter for VS Code.",
 	"author": "lkytal",
 	"publisher": "lkytal",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"license": "GPL",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
https://qiita.com/shoooo/items/a8d26d8d0c4eae6adab2#%E3%83%89%E3%83%A1%E3%82%A4%E3%83%B3
The README.md revised as the domain has been updated from "vsmarketplacebadge.apphb.com" to "vsmarketplacebadges.dev".
Also, I didn't think the Dependency status part was necessary (apologies if it wasn't), so I replaced it with a version badge.